### PR TITLE
Fixed PHP warning Trying to access array offset on value of type int in get_index_names().

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -411,7 +411,7 @@ class Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function get_index_names() {
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
+		$sites = ( is_multisite() ) ? Utils\get_sites() : array( array( 'blog_id' => get_current_blog_id() ) );
 
 		$all_indexables = Indexables::factory()->get_all();
 


### PR DESCRIPTION
Problem
- Running `wp elasticpress get-indexes` causes the following PHP warnings:

```
PHP Warning:  Trying to access array offset on value of type int
  in /wp-content/plugins/elasticpress/includes/classes/Command.php on line 427
PHP Warning:  Trying to access array offset on value of type int
  in /wp-content/plugins/elasticpress/includes/classes/Command.php on line 430
```

Cause
- On non-multi-site installations, Command::get_index_names() uses a pseudo list of sites only containing the current/single site. The element in this array matches the expected structure of a [WP_Site](https://developer.wordpress.org/reference/classes/wp_site/), but the outer array for the list is missing.

Proposed solution
1. Fix the array structure to return a list of sites.
