### PR TITLE
Fixed WooCommerc data privacy eraser query deletes all orders with ElasticPress.

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -1038,7 +1038,7 @@ abstract class Indexable {
 				if ( false !== $terms_obj ) {
 					$meta_filter[] = $terms_obj;
 				}
-			} elseif ( is_array( $single_meta_query ) && isset( $single_meta_query[0] ) && is_array( $single_meta_query[0] ) ) {
+			} elseif ( is_array( $single_meta_query ) ) {
 				/**
 				 * Handle multidimensional array. Something like:
 				 *


### PR DESCRIPTION
Scope
- Major loss of customer data, only recoverable from backups.

Context/Requirements
- ElasticPress is enabled for both admin and AJAX queries.
  ```php
      add_filter('ep_admin_wp_query_integration', '__return_true');
      add_filter('ep_ajax_wp_query_integration', '__return_true');
  ```

Problem
- When using the built-in tool for removing personal data in WordPress Core on `/wp-admin/erase-personal-data.php`, all orders (⚠️) are anonymized instead of only the requested ones.

Cause
1. WooCommerce sets WC_Order_Query filters on `'customer'` in
    https://github.com/woocommerce/woocommerce/blob/9e9b4ef844ef015388c21a401aba7bdee11a0d72/plugins/woocommerce/includes/class-wc-privacy-erasers.php#L125-L133

2. The WooCommerce order data store expands the `'customer'` parameter in
    https://github.com/woocommerce/woocommerce/blob/9e9b4ef844ef015388c21a401aba7bdee11a0d72/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L453-L466

    into a meta query, resulting in the following meta query:
    ```
        [meta_query] => Array
            (
                [0] => Array
                    (
                        [relation] => OR
                        [customer_emails] => Array
                            (
                                [key] => _billing_email
                                [value] => Array
                                    (
                                        [0] => example@example.com
                                    )
                                [compare] => IN
                            )
                        [customer_ids] => Array
                            (
                                [key] => _customer_user
                                [value] => Array
                                    (
                                        [0] => 12345
                                    )
                                [compare] => IN
                            )
                    )
            )
    ```
    ☝️ Note that WooCommerce is using named keys (`customer_emails` and `customer_ids`) for the conditions and not indexed keys.

2. The meta query processing in Indexable only expects indexed keys, and there is no following handling of other array keys:
    https://github.com/10up/ElasticPress/blob/c51729ed23184fe302240f67a49fbfcdd64548ad/includes/classes/Indexable.php#L1041

     so the meta query parameters are ignored altogether – resulting in the following, **unfiltered** ES statement querying all orders:
    ```
    GET active-post-1/_search
    {
      "from": 0,
      "size": 10,
      "sort": [
        {
          "post_date": {
            "order": "desc"
          }
        }
      ],
      "query": {
        "match_all": {
          "boost": 1
        }
      },
      "post_filter": {
        "bool": {
          "must": [
            {
              "terms": {
                "post_type.raw": [
                  "shop_order",
                  "shop_order_refund"
                ]
              }
            },
            {
              "terms": {
                "post_status": [
                  "wc-pending",
                  "wc-processing",
                  "wc-on-hold",
                  "wc-completed",
                  "wc-cancelled",
                  "wc-refunded",
                  "wc-failed",
                  "wc-checkout-draft"
                ]
              }
            }
          ]
        }
      }
    }
    ```

4. All orders are getting anonymized.
![image](https://user-images.githubusercontent.com/41992/187777772-71cf52d5-bcf0-4ba9-97a1-61f9c5ec375b.png)

Proposed solution
1. Remove the condition that is only considering meta query conditions in indexed keys.

Notes
- It is probably true that all documentation and examples about meta query conditions is using indexed keys, but neither the docs nor the meta query code is stating in any way that this would be a requirement.
- Therefore, using named keys like WooCommerce is perfectly legit.